### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/components/Statistics.tsx
+++ b/components/Statistics.tsx
@@ -103,7 +103,12 @@ const Statistics: React.FC<StatisticsProps> = ({ stages, progress, onBack }) => 
   return (
     <div className="flex-1 container mx-auto px-4 py-8 max-w-5xl flex flex-col h-full">
       <div className="flex items-center gap-4 mb-10">
-        <button onClick={() => { playMenuClick(); onBack(); }} className="p-3 hover:bg-slate-800 rounded-full transition-colors group" title={t('statistics.back')}>
+        <button
+          onClick={() => { playMenuClick(); onBack(); }}
+          className="p-3 hover:bg-slate-800 rounded-full transition-colors group"
+          title={t('statistics.back')}
+          aria-label={t('statistics.back')}
+        >
           <Home size={24} className="text-slate-400 group-hover:text-white" />
         </button>
         <h1 className="text-3xl font-bold text-white">{t('statistics.title')}</h1>

--- a/components/TypingGame.tsx
+++ b/components/TypingGame.tsx
@@ -249,6 +249,7 @@ const TypingGame: React.FC<TypingGameProps> = ({ stage, subLevelId, content: con
             onClick={() => (stage.id === 15 ? finishGame() : onBack())}
             className="p-2 hover:bg-slate-700 rounded-full transition-colors"
             title={stage.id === 15 ? t('typing.finishStats') : t('typing.backToMenu')}
+            aria-label={stage.id === 15 ? t('typing.finishStats') : t('typing.backToMenu')}
           >
               <Home size={20} className="text-slate-400 hover:text-white" />
           </button>
@@ -285,7 +286,12 @@ const TypingGame: React.FC<TypingGameProps> = ({ stage, subLevelId, content: con
           </div>
         </div>
 
-        <button onClick={onRetry} className="p-2 hover:bg-slate-700 rounded-full transition-colors" title={t('typing.restart')}>
+        <button
+          onClick={onRetry}
+          className="p-2 hover:bg-slate-700 rounded-full transition-colors"
+          title={t('typing.restart')}
+          aria-label={t('typing.restart')}
+        >
           <RotateCcw size={20} className="text-slate-400 hover:text-white" />
         </button>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons in `TypingGame.tsx` and `Statistics.tsx`.
🎯 Why: These buttons (Home/Back, Retry) were only accessible via mouse (tooltip) or visual inspection. Screen reader users would not know their purpose.
📸 Before/After: Visuals are unchanged.
♿ Accessibility: Screen readers will now announce "Back to Menu", "Finish & Stats", or "Restart" instead of ignoring the button or reading generic text.

---
*PR created automatically by Jules for task [10682207867215081407](https://jules.google.com/task/10682207867215081407) started by @timbornemann*