### PR TITLE
🎨 Palette: Add accessible labels to level buttons

### DIFF
--- a/components/StageCard.tsx
+++ b/components/StageCard.tsx
@@ -264,6 +264,7 @@ const StageCard: React.FC<StageCardProps> = ({
              <button
                 disabled={isLocked}
                 onClick={() => onStartLevel(stage, 1)}
+                aria-label={t('stageCard.ariaEndless')}
                 className={`
                   relative group flex flex-col items-center justify-center transition-all duration-500
                   ${isStageFocused ? 'scale-110' : ''}
@@ -335,11 +336,23 @@ const StageCard: React.FC<StageCardProps> = ({
                   else if (subLevelId === progress.unlockedSubLevelId) status = 'active';
                 }
 
+                let ariaLabel = t('stageCard.ariaLocked', { level: subLevelId });
+                if (status === 'completed') {
+                  ariaLabel = t('stageCard.ariaCompleted', { level: subLevelId });
+                } else if (status === 'active') {
+                  if (isMaster) {
+                    ariaLabel = t('stageCard.ariaMaster');
+                  } else {
+                    ariaLabel = t('stageCard.ariaActive', { level: subLevelId });
+                  }
+                }
+
                 return (
                   <button
                     key={subLevelId}
                     disabled={status === 'locked'}
                     onClick={() => onStartLevel(stage, subLevelId)}
+                    aria-label={ariaLabel}
                     className={`
                       absolute group/btn flex flex-col items-center justify-center transition-all duration-300
                       -translate-x-1/2 -translate-y-1/2

--- a/i18n.ts
+++ b/i18n.ts
@@ -114,6 +114,11 @@ export const translations = {
       level: 'Level {level}',
       endlessPractice: 'Endless practice (Mega level)',
       wordSentence: 'Word & sentence',
+      ariaLocked: 'Level {level}, Locked',
+      ariaCompleted: 'Level {level}, Completed',
+      ariaActive: 'Start Level {level}',
+      ariaMaster: 'Start Master Level',
+      ariaEndless: 'Start Endless Mode',
     },
     typing: {
       finishStats: 'Finish & view stats',
@@ -397,6 +402,11 @@ export const translations = {
       level: 'Level {level}',
       endlessPractice: 'Endlos-Üben (Mega-Level)',
       wordSentence: 'Wort & Satz',
+      ariaLocked: 'Level {level}, Gesperrt',
+      ariaCompleted: 'Level {level}, Abgeschlossen',
+      ariaActive: 'Starte Level {level}',
+      ariaMaster: 'Starte Meisterprüfung',
+      ariaEndless: 'Starte Endlos-Modus',
     },
     typing: {
       finishStats: 'Beenden & Statistik anzeigen',


### PR DESCRIPTION
*   💡 What: Added `aria-label` attributes to the stage level buttons and the endless mode button.
*   🎯 Why: Screen reader users could not identify the state (locked, active, completed) or the purpose of the level buttons, as they only contained icons or numbers without context.
*   ♿ Accessibility: Buttons now announce "Level X, Locked", "Level X, Completed", or "Start Level X" (and "Start Master Level") properly.
*   Ref: Updated `i18n.ts` with new keys and `StageCard.tsx` to apply them.

---
*PR created automatically by Jules for task [7770749634784411904](https://jules.google.com/task/7770749634784411904) started by @timbornemann*