### PR TITLE
⚡ Bolt: Performance - Isolate WPM Timer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-22 - Game Loop vs UI Rendering
 **Learning:** In a game-like React app with a timer loop (WPM update every second), the entire component tree re-renders on every tick. Visual components like the Scrolling Tape (mapping hundreds of DOM nodes) and Virtual Keyboard (calculating styles for 60+ keys) were re-rendering unnecessarily even when user input didn't change.
 **Action:** Extract expensive visual components (`TypingTape`, `VirtualKeyboard`) and use `React.memo` to isolate them from the "Game Loop" state updates (WPM, time elapsed) that don't affect their appearance.
+
+## 2025-02-24 - Isolating Timer Updates
+**Learning:** Even with `React.memo` on child components, the parent `TypingGame` component was still re-rendering every second due to a local `wpm` state update driven by a `setInterval`. This caused unnecessary reconciliation overhead (creating new object references, re-evaluating hook dependencies) for the entire game tree.
+**Action:** Extracted the WPM timer and display into a separate `<WpmDisplay />` component. This isolates the "every second" state update to a small leaf component, preventing the heavy parent and its other children from re-rendering unless the user actually types.

--- a/components/WpmDisplay.tsx
+++ b/components/WpmDisplay.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useI18n } from '../hooks/useI18n';
+
+interface WpmDisplayProps {
+  startTime: number | null;
+  inputIndex: number;
+  totalCharsTyped: number;
+  stageId: number;
+}
+
+export const WpmDisplay: React.FC<WpmDisplayProps> = ({ startTime, inputIndex, totalCharsTyped, stageId }) => {
+  const { t } = useI18n();
+  const [wpm, setWpm] = useState(0);
+
+  const stateRef = useRef({ startTime, inputIndex, totalCharsTyped, stageId });
+  useEffect(() => {
+    stateRef.current = { startTime, inputIndex, totalCharsTyped, stageId };
+  }, [startTime, inputIndex, totalCharsTyped, stageId]);
+
+  useEffect(() => {
+    // Reset WPM if game is reset (startTime becomes null)
+    if (startTime === null) {
+      setWpm(0);
+    }
+  }, [startTime]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const { startTime: st, inputIndex: idx, totalCharsTyped: total, stageId: sId } = stateRef.current;
+      if (st == null) {
+          return;
+      }
+      const now = Date.now();
+      const minutes = (now - st) / 60000;
+      const chars = sId === 15 ? total + idx : idx;
+      const words = chars / 5;
+      const currentWpm = Math.round(words / minutes) || 0;
+      setWpm(currentWpm);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="text-center">
+      <p className="text-xs text-slate-400 uppercase tracking-wider">{t('typing.wpm')}</p>
+      <p className="text-2xl font-mono font-bold text-emerald-400">{wpm}</p>
+    </div>
+  );
+};


### PR DESCRIPTION
Extracted the WPM timer and display into a separate component to isolate state updates. This prevents the entire `TypingGame` tree from re-rendering every second, significantly reducing reconciliation overhead. Verified with Playwright.

---
*PR created automatically by Jules for task [14554322244294363367](https://jules.google.com/task/14554322244294363367) started by @timbornemann*